### PR TITLE
Track bytes for each outgoing network message

### DIFF
--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
@@ -1,33 +1,15 @@
 ﻿using Harmony;
 using Network;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
 
 namespace RustServerMetrics.HarmonyPatches
 {
     [HarmonyPatch(typeof(NetWrite), nameof(NetWrite.PacketID))]
     public class NetWrite_PacketID_Patch
     {
-        [HarmonyTranspiler]
-        public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> originalInstructions)
+        [HarmonyPostfix]
+        public static void Postfix(Message.Type val)
         {
-            List<CodeInstruction> retList = new List<CodeInstruction>(originalInstructions);
-
-            var fieldInfo = typeof(SingletonComponent<MetricsLogger>)
-                .GetField(nameof(SingletonComponent<MetricsLogger>.Instance), BindingFlags.Static | BindingFlags.Public);
-
-            var methodInfo = typeof(MetricsLogger)
-                .GetMethod(nameof(MetricsLogger.OnNetWritePacketID), BindingFlags.Instance | BindingFlags.NonPublic);
-
-            retList.InsertRange(retList.Count - 1, new CodeInstruction[]
-            {
-                new CodeInstruction(OpCodes.Ldsfld, fieldInfo),
-                new CodeInstruction(OpCodes.Ldarg_1),
-                new CodeInstruction(OpCodes.Call, methodInfo)
-            });
-
-            return retList;
+            MetricsLogger.Instance.OnNetWritePacketID(val);
         }
     }
 }

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
@@ -22,6 +22,7 @@ namespace RustServerMetrics.HarmonyPatches
 
             retList.InsertRange(retList.Count - 1, new CodeInstruction[]
             {
+                new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldsfld, fieldInfo),
                 new CodeInstruction(OpCodes.Ldarg_1),
                 new CodeInstruction(OpCodes.Call, methodInfo)

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
@@ -1,34 +1,15 @@
 ﻿using Harmony;
 using Network;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
 
 namespace RustServerMetrics.HarmonyPatches
 {
     [HarmonyPatch(typeof(NetWrite), nameof(NetWrite.Send))]
     public class NetWrite_Send_Patch
     {
-        [HarmonyTranspiler]
-        public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> originalInstructions)
+        [HarmonyPostfix]
+        public static void Postfix(NetWrite __instance, SendInfo info)
         {
-            List<CodeInstruction> retList = new List<CodeInstruction>(originalInstructions);
-
-            var fieldInfo = typeof(SingletonComponent<MetricsLogger>)
-                .GetField(nameof(SingletonComponent<MetricsLogger>.Instance), BindingFlags.Static | BindingFlags.Public);
-
-            var methodInfo = typeof(MetricsLogger)
-                .GetMethod(nameof(MetricsLogger.OnNetWriteSend), BindingFlags.Instance | BindingFlags.NonPublic);
-
-            retList.InsertRange(retList.Count - 1, new CodeInstruction[]
-            {
-                new CodeInstruction(OpCodes.Ldarg_0),
-                new CodeInstruction(OpCodes.Ldsfld, fieldInfo),
-                new CodeInstruction(OpCodes.Ldarg_1),
-                new CodeInstruction(OpCodes.Call, methodInfo)
-            });
-
-            return retList;
+            MetricsLogger.Instance.OnNetWriteSend(__instance, info);
         }
     }
 }

--- a/src/RustServerMetrics/HarmonyPatches/Performance_FPSTimer_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Performance_FPSTimer_Patch.cs
@@ -1,31 +1,14 @@
 ﻿using Harmony;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
 
 namespace RustServerMetrics.HarmonyPatches
 {
     [HarmonyPatch(typeof(Performance), "FPSTimer")]
     public class Performance_FPSTimer_Patch
     {
-        [HarmonyTranspiler]
-        public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> originalInstructions)
+        [HarmonyPostfix]
+        public static void Postfix()
         {
-            List<CodeInstruction> retList = new List<CodeInstruction>(originalInstructions);
-
-            var fieldInfo = typeof(SingletonComponent<MetricsLogger>)
-                .GetField(nameof(SingletonComponent<MetricsLogger>.Instance), BindingFlags.Static | BindingFlags.Public);
-
-            var methodInfo = typeof(MetricsLogger)
-                .GetMethod(nameof(MetricsLogger.OnPerformanceReportGenerated), BindingFlags.Instance | BindingFlags.NonPublic);
-
-            retList.InsertRange(retList.Count - 1, new CodeInstruction[]
-            {
-                new CodeInstruction(OpCodes.Ldsfld, fieldInfo),
-                new CodeInstruction(OpCodes.Call, methodInfo)
-            });
-
-            return retList;
+            MetricsLogger.Instance.OnPerformanceReportGenerated();
         }
     }
 }

--- a/update-win-staging.bat
+++ b/update-win-staging.bat
@@ -1,3 +1,3 @@
 pwsh scripts\SteamDownloader.ps1 -steam_appid 258550 -steam_branch staging -platform windows -deps_dir "../raw-deps"
-pwsh scripts\unprivate-dependencies.ps1 -outputPath "deps/windows/" -inputPath "raw-deps/linux/RustDedicated_Data/Managed"
+pwsh scripts\unprivate-dependencies.ps1 -outputPath "deps/windows/" -inputPath "raw-deps/windows/RustDedicated_Data/Managed"
 PAUSE


### PR DESCRIPTION
Compiles but untested.

I added the bytes in the same series as the count of network messages. It may be easier to graph when they are separate series rather than separate fields but I cba copy pasting the whole serialization code. 