### PR TITLE
Fix issue where RustServerMetrics is not considering the fact that the server can be ready earlier than it thinks

### DIFF
--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
@@ -9,6 +9,9 @@ namespace RustServerMetrics.HarmonyPatches
         [HarmonyPostfix]
         public static void Postfix(Message.Type val)
         {
+            if (SingletonComponent<MetricsLogger>.Instance == null)
+                return;
+            
             MetricsLogger.Instance.OnNetWritePacketID(val);
         }
     }

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
@@ -9,7 +9,7 @@ namespace RustServerMetrics.HarmonyPatches
         [HarmonyPostfix]
         public static void Postfix(Message.Type val)
         {
-            MetricsLogger?.Instance?.OnNetWritePacketID(val);
+            SingletonComponent<MetricsLogger>.Instance?.OnNetWritePacketID(val);
         }
     }
 }

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
@@ -9,10 +9,7 @@ namespace RustServerMetrics.HarmonyPatches
         [HarmonyPostfix]
         public static void Postfix(Message.Type val)
         {
-            if (SingletonComponent<MetricsLogger>.Instance == null)
-                return;
-            
-            MetricsLogger.Instance.OnNetWritePacketID(val);
+            MetricsLogger?.Instance?.OnNetWritePacketID(val);
         }
     }
 }

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
@@ -9,10 +9,7 @@ namespace RustServerMetrics.HarmonyPatches
         [HarmonyPostfix]
         public static void Postfix(NetWrite __instance, SendInfo info)
         {
-            if (SingletonComponent<MetricsLogger>.Instance == null)
-                return;
-            
-            MetricsLogger.Instance.OnNetWriteSend(__instance, info);
+            MetricsLogger?.Instance?.OnNetWriteSend(__instance, info);
         }
     }
 }

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
@@ -9,7 +9,7 @@ namespace RustServerMetrics.HarmonyPatches
         [HarmonyPostfix]
         public static void Postfix(NetWrite __instance, SendInfo info)
         {
-            MetricsLogger?.Instance?.OnNetWriteSend(__instance, info);
+            SingletonComponent<MetricsLogger>.Instance?.OnNetWriteSend(__instance, info);
         }
     }
 }

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
@@ -9,6 +9,9 @@ namespace RustServerMetrics.HarmonyPatches
         [HarmonyPostfix]
         public static void Postfix(NetWrite __instance, SendInfo info)
         {
+            if (SingletonComponent<MetricsLogger>.Instance == null)
+                return;
+            
             MetricsLogger.Instance.OnNetWriteSend(__instance, info);
         }
     }

--- a/src/RustServerMetrics/HarmonyPatches/ServerMgr_OpenConnection_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/ServerMgr_OpenConnection_Patch.cs
@@ -8,7 +8,7 @@ namespace RustServerMetrics.HarmonyPatches
         [HarmonyPostfix]
         public static void Postfix()
         {
-            MetricsLogger.Instance?.OnServerStarted();
+            MetricsLogger?.Instance?.OnServerStarted();
         }
     }
 }

--- a/src/RustServerMetrics/HarmonyPatches/ServerMgr_OpenConnection_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/ServerMgr_OpenConnection_Patch.cs
@@ -8,7 +8,7 @@ namespace RustServerMetrics.HarmonyPatches
         [HarmonyPostfix]
         public static void Postfix()
         {
-            MetricsLogger?.Instance?.OnServerStarted();
+            SingletonComponent<MetricsLogger>.Instance?.OnServerStarted();
         }
     }
 }


### PR DESCRIPTION
Plugin EarlyQ allows server to start way earlier than RustServerMetrics expects.

This pull request fixes an NRE that will be thrown when a player joins the server before its normal start