### PR TITLE
Upgrading Harmony to 2.x for the May 2024 update

### DIFF
--- a/src/RustServerMetrics/HarmonyPatches/BasePlayer_OnDisconnected_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/BasePlayer_OnDisconnected_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/src/RustServerMetrics/HarmonyPatches/BasePlayer_PerformanceReport_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/BasePlayer_PerformanceReport_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/src/RustServerMetrics/HarmonyPatches/BasePlayer_PlayerInit_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/BasePlayer_PlayerInit_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/RustServerMetrics/HarmonyPatches/Bootstrap_StartServer_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Bootstrap_StartServer_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/ConsoleSystem_Internal_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/ConsoleSystem_Internal_Patch.cs
@@ -16,7 +16,7 @@ namespace RustServerMetrics.HarmonyPatches.Delayed
         {
             if (!RustServerMetricsLoader.__serverStarted)
             {
-                Debug.Log("Cannot patch ConsoleSystem_Internal_Patch yet. We will patch it upon server start.");
+                Debug.Log("Note: Cannot patch ConsoleSystem_Internal_Patch yet. We will patch it upon server start.");
                 return false;
             }
 

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/ConsoleSystem_Internal_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/ConsoleSystem_Internal_Patch.cs
@@ -1,16 +1,30 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using RustServerMetrics.HarmonyPatches.Utility;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using UnityEngine;
 
 namespace RustServerMetrics.HarmonyPatches.Delayed
 {
     [DelayedHarmonyPatch]
+    [HarmonyPatch]
     internal class ConsoleSystem_Internal_Patch
     {
+        [HarmonyPrepare]
+        public static bool Prepare()
+        {
+            if (!RustServerMetricsLoader.__serverStarted)
+            {
+                Debug.Log("Cannot patch ConsoleSystem_Internal_Patch yet. We will patch it upon server start.");
+                return false;
+            }
+
+            return true;
+        }
+        
         [HarmonyTargetMethods]
-        public static IEnumerable<MethodBase> TargetMethods(HarmonyInstance harmonyInstance)
+        public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance)
         {
             yield return AccessTools.DeclaredMethod(typeof(ConsoleSystem), nameof(ConsoleSystem.Internal));
         }

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/InvokeHandlerBase_DoTick_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/InvokeHandlerBase_DoTick_Patch.cs
@@ -1,14 +1,16 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using RustServerMetrics.HarmonyPatches.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using UnityEngine;
 
 namespace RustServerMetrics.HarmonyPatches.Delayed
 {
     [DelayedHarmonyPatch]
+    [HarmonyPatch]
     internal static class InvokeHandlerBase_DoTick_Patch
     {
         static System.Diagnostics.Stopwatch _stopwatch = new System.Diagnostics.Stopwatch();
@@ -21,8 +23,20 @@ namespace RustServerMetrics.HarmonyPatches.Delayed
             new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(Action), nameof(Action.Invoke)))
         };
 
+        [HarmonyPrepare]
+        public static bool Prepare()
+        {
+            if (!RustServerMetricsLoader.__serverStarted)
+            {
+                Debug.Log("Cannot patch InvokeHandlerBase_DoTick_Patch yet. We will patch it upon server start.");
+                return false;
+            }
+
+            return true;
+        }
+        
         [HarmonyTargetMethods]
-        public static IEnumerable<MethodBase> TargetMethods(HarmonyInstance harmonyInstance)
+        public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance)
         {
             yield return AccessTools.DeclaredMethod(typeof(InvokeHandlerBase<InvokeHandler>), nameof(InvokeHandlerBase<InvokeHandler>.DoTick));
         }

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/InvokeHandlerBase_DoTick_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/InvokeHandlerBase_DoTick_Patch.cs
@@ -28,7 +28,7 @@ namespace RustServerMetrics.HarmonyPatches.Delayed
         {
             if (!RustServerMetricsLoader.__serverStarted)
             {
-                Debug.Log("Cannot patch InvokeHandlerBase_DoTick_Patch yet. We will patch it upon server start.");
+                Debug.Log("Note: Cannot patch InvokeHandlerBase_DoTick_Patch yet. We will patch it upon server start.");
                 return false;
             }
 

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/ObjectWorkQueue_RunJob_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/ObjectWorkQueue_RunJob_Patch.cs
@@ -18,7 +18,7 @@ namespace RustServerMetrics.HarmonyPatches.Delayed
         {
             if (!RustServerMetricsLoader.__serverStarted)
             {
-                Debug.Log("Cannot patch ObjectWorkQueue_RunJob_Patch yet. We will patch it upon server start.");
+                Debug.Log("Note: Cannot patch ObjectWorkQueue_RunJob_Patch yet. We will patch it upon server start.");
                 return false;
             }
 

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/ObjectWorkQueue_RunJob_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/ObjectWorkQueue_RunJob_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using RustServerMetrics.HarmonyPatches.Utility;
 using System;
 using System.Collections.Generic;
@@ -10,10 +10,23 @@ using UnityEngine;
 namespace RustServerMetrics.HarmonyPatches.Delayed
 {
     [DelayedHarmonyPatch]
+    [HarmonyPatch]
     internal static class ObjectWorkQueue_RunJob_Patch
     {
+        [HarmonyPrepare]
+        public static bool Prepare()
+        {
+            if (!RustServerMetricsLoader.__serverStarted)
+            {
+                Debug.Log("Cannot patch ObjectWorkQueue_RunJob_Patch yet. We will patch it upon server start.");
+                return false;
+            }
+
+            return true;
+        }
+        
         [HarmonyTargetMethods]
-        public static IEnumerable<MethodBase> TargetMethods(HarmonyInstance harmonyInstance)
+        public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance)
         {
             var assemblyCSharp = typeof(BaseNetworkable).Assembly;
             Stack<Type> typesToScan = new Stack<Type>(assemblyCSharp.GetTypes());

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/RPCServer_Attribute_Method_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/RPCServer_Attribute_Method_Patch.cs
@@ -18,7 +18,7 @@ namespace RustServerMetrics.HarmonyPatches.Delayed
         {
             if (!RustServerMetricsLoader.__serverStarted)
             {
-                Debug.Log("Cannot patch RPCServer_Attribute_Method_Patch yet. We will patch it upon server start.");
+                Debug.Log("Note: Cannot patch RPCServer_Attribute_Method_Patch yet. We will patch it upon server start.");
                 return false;
             }
 

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/RPCServer_Attribute_Method_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/RPCServer_Attribute_Method_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using RustServerMetrics.HarmonyPatches.Utility;
 using System;
 using System.Collections.Generic;
@@ -10,10 +10,23 @@ using UnityEngine;
 namespace RustServerMetrics.HarmonyPatches.Delayed
 {
     [DelayedHarmonyPatch]
+    [HarmonyPatch]
     internal class RPCServer_Attribute_Method_Patch
     {
+        [HarmonyPrepare]
+        public static bool Prepare()
+        {
+            if (!RustServerMetricsLoader.__serverStarted)
+            {
+                Debug.Log("Cannot patch RPCServer_Attribute_Method_Patch yet. We will patch it upon server start.");
+                return false;
+            }
+
+            return true;
+        }
+        
         [HarmonyTargetMethods]
-        public static IEnumerable<MethodBase> TargetMethods(HarmonyInstance harmonyInstance)
+        public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance)
         {
             var baseNetworkableType = typeof(BaseNetworkable);
             var baseNetworkableAssembly = baseNetworkableType.Assembly;

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/ServerMgr_Metrics_Patches.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/ServerMgr_Metrics_Patches.cs
@@ -18,7 +18,7 @@ internal static class ServerMgr_Metrics_Patches
     {
         if (!RustServerMetricsLoader.__serverStarted)
         {
-            Debug.Log("Cannot patch ServerMgr_Metrics_Patches yet. We will patch it upon server start.");
+            Debug.Log("Note: Cannot patch ServerMgr_Metrics_Patches yet. We will patch it upon server start.");
             return false;
         }
 

--- a/src/RustServerMetrics/HarmonyPatches/Delayed/ServerMgr_Metrics_Patches.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Delayed/ServerMgr_Metrics_Patches.cs
@@ -3,17 +3,30 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using Harmony;
+using HarmonyLib;
 using RustServerMetrics.HarmonyPatches.Utility;
 using UnityEngine;
 
 namespace RustServerMetrics.HarmonyPatches.Delayed;
 
 [DelayedHarmonyPatch]
+[HarmonyPatch]
 internal static class ServerMgr_Metrics_Patches
 {
+    [HarmonyPrepare]
+    public static bool Prepare()
+    {
+        if (!RustServerMetricsLoader.__serverStarted)
+        {
+            Debug.Log("Cannot patch ServerMgr_Metrics_Patches yet. We will patch it upon server start.");
+            return false;
+        }
+
+        return true;
+    }
+    
     [HarmonyTargetMethods]
-    public static IEnumerable<MethodBase> TargetMethods(HarmonyInstance harmonyInstance)
+    public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance)
     {
         yield return AccessTools.Method(typeof(ServerMgr), nameof(ServerMgr.Update));
         yield return AccessTools.Method(typeof(ServerBuildingManager), nameof(ServerBuildingManager.Cycle));

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_PacketID_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Network;
 
 namespace RustServerMetrics.HarmonyPatches

--- a/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/NetWrite_Send_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using Network;
 
 namespace RustServerMetrics.HarmonyPatches

--- a/src/RustServerMetrics/HarmonyPatches/OxideMod_OnFrame_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/OxideMod_OnFrame_Patch.cs
@@ -1,149 +1,149 @@
-﻿using Harmony;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
-
-namespace RustServerMetrics.HarmonyPatches
-{
-    [HarmonyPatch]
-    public static class OxideMod_OnFrame_Patch
-    {
-        const string OxideCore_AssemblyName = "Oxide.Core";
-
-        const string OxidePluginType_FullName = "Oxide.Core.Plugins.Plugin";
-        const string OxideInterfaceType_FullName = "Oxide.Core.Interface";
-        const string OxideOxideModType_FullName = "Oxide.Core.OxideMod";
-        const string OxidePluginManagerType_FullName = "Oxide.Core.Plugins.PluginManager";
-
-        static Assembly _oxideCoreAssembly = null;
-        public static float nextTick = 0f;
-
-        [HarmonyTargetMethods]
-        public static IEnumerable<MethodBase> TargetMethods(HarmonyInstance harmonyInstance)
-        {
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            for (int i = 0; i < assemblies.Length; i++)
-            {
-                var assembly = assemblies[i];
-                if (!string.Equals(assembly.GetName().Name, OxideCore_AssemblyName, StringComparison.OrdinalIgnoreCase)) continue;
-                _oxideCoreAssembly = assembly;
-                break;
-            }
-
-            if (_oxideCoreAssembly == null)
-                return Array.Empty<MethodBase>();
-
-            var oxideModType = _oxideCoreAssembly.GetType(OxideOxideModType_FullName, false);
-
-            if (oxideModType == null)
-                return Array.Empty<MethodBase>();
-
-            var targetMethod = oxideModType.GetMethod("OnFrame", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(float) }, null);
-
-            if (targetMethod == null)
-                return Array.Empty<MethodBase>();
-
-            return new MethodBase[] { targetMethod };
-        }
-
-        [HarmonyTranspiler]
-        public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> originalInstructions, ILGenerator ilGenerator)
-        {
-            var skipProcessingLabel = ilGenerator.DefineLabel();
-            var loopHeadLabel = ilGenerator.DefineLabel();
-            var loopBodyLabel = ilGenerator.DefineLabel();
-
-            var oxidePluginType = _oxideCoreAssembly.GetType(OxidePluginType_FullName, true);
-            var enumerableType = typeof(IEnumerable<>);
-            var oxidePluginEnumerableType = enumerableType.MakeGenericType(oxidePluginType);
-            var enumeratorType = typeof(IEnumerator<>);
-            var oxidePluginEnumeratorType = enumeratorType.MakeGenericType(oxidePluginType);
-
-            var enumeratorLocal = ilGenerator.DeclareLocal(oxidePluginEnumeratorType);
-            var dictionaryLocal = ilGenerator.DeclareLocal(typeof(Dictionary<string, double>));
-            var pluginLocal = ilGenerator.DeclareLocal(oxidePluginType);
-            var currentTimeLocal = ilGenerator.DeclareLocal(typeof(float));
-
-            var nextTickFieldInfo = typeof(OxideMod_OnFrame_Patch).GetField(nameof(nextTick), BindingFlags.Public | BindingFlags.Static);
-
-            List<CodeInstruction> retList = new List<CodeInstruction>(originalInstructions);
-
-            retList[0].labels.Add(skipProcessingLabel);
-
-            var unityGetTimeMethodInfo = typeof(UnityEngine.Time).GetProperty(nameof(UnityEngine.Time.time)).GetGetMethod();
-            var oxideGetterMethodInfo = _oxideCoreAssembly.GetType(OxideInterfaceType_FullName, true).GetProperty("Oxide").GetGetMethod();
-            var rootPluginManagerGetterMethodInfo = _oxideCoreAssembly.GetType(OxideOxideModType_FullName, true).GetProperty("RootPluginManager").GetGetMethod();
-            var getPluginsMethodInfo = _oxideCoreAssembly.GetType(OxidePluginManagerType_FullName, true).GetMethod("GetPlugins");
-            var getPluginNameGetterMethodInfo = oxidePluginType.GetProperty("Name").GetGetMethod();
-            var getPluginTotalHookTimeGetterMethodInfo = oxidePluginType.GetProperty("TotalHookTime").GetGetMethod();
-            var getEnumeratorMethodInfo = oxidePluginEnumerableType.GetMethod("GetEnumerator");
-
-            var hookFieldInfo = typeof(SingletonComponent<MetricsLogger>)
-                .GetField(nameof(SingletonComponent<MetricsLogger>.Instance), BindingFlags.Static | BindingFlags.Public);
-
-            var hookMethodInfo = typeof(MetricsLogger)
-                .GetMethod(nameof(MetricsLogger.OnOxidePluginMetrics), BindingFlags.Instance | BindingFlags.NonPublic);
-
-            retList.InsertRange(0, new CodeInstruction[]
-            {
-                new CodeInstruction(OpCodes.Ldsfld, hookFieldInfo),
-                new CodeInstruction(OpCodes.Brfalse_S, skipProcessingLabel),
-
-                new CodeInstruction(OpCodes.Call, unityGetTimeMethodInfo),
-                new CodeInstruction(OpCodes.Stloc, currentTimeLocal.LocalIndex),
-
-                new CodeInstruction(OpCodes.Ldsfld, nextTickFieldInfo),
-                new CodeInstruction(OpCodes.Ldloc, currentTimeLocal.LocalIndex),
-                new CodeInstruction(OpCodes.Bgt_S, skipProcessingLabel),
-
-                new CodeInstruction(OpCodes.Ldloc, currentTimeLocal.LocalIndex),
-                new CodeInstruction(OpCodes.Ldc_R4, 1f),
-                new CodeInstruction(OpCodes.Add),
-                new CodeInstruction(OpCodes.Stsfld, nextTickFieldInfo),
-
-                new CodeInstruction(OpCodes.Call, oxideGetterMethodInfo),
-                new CodeInstruction(OpCodes.Callvirt, rootPluginManagerGetterMethodInfo),
-                new CodeInstruction(OpCodes.Callvirt, getPluginsMethodInfo),
-                new CodeInstruction(OpCodes.Callvirt, getEnumeratorMethodInfo),
-                new CodeInstruction(OpCodes.Stloc, enumeratorLocal.LocalIndex),
-
-                new CodeInstruction(OpCodes.Newobj, typeof(Dictionary<string, double>).GetConstructor(Type.EmptyTypes)),
-                new CodeInstruction(OpCodes.Stloc, dictionaryLocal.LocalIndex),
-
-                // Jump to Loop Head
-                new CodeInstruction(OpCodes.Br_S, loopHeadLabel),
-
-                // Loop Body Start
-                new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex) { labels = { loopBodyLabel } },
-                new CodeInstruction(OpCodes.Callvirt, oxidePluginEnumeratorType.GetProperty(nameof(IEnumerator.Current)).GetGetMethod()),
-                new CodeInstruction(OpCodes.Stloc, pluginLocal.LocalIndex),
-                new CodeInstruction(OpCodes.Ldloc, dictionaryLocal.LocalIndex),
-                new CodeInstruction(OpCodes.Ldloc, pluginLocal.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, getPluginNameGetterMethodInfo),
-                new CodeInstruction(OpCodes.Ldloc, pluginLocal.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, getPluginTotalHookTimeGetterMethodInfo),
-                new CodeInstruction(OpCodes.Callvirt, dictionaryLocal.LocalType.GetMethod("set_Item")),
-                // Loop Body End
-
-                // Loop Head Start
-                new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex) { labels = { loopHeadLabel } },
-                new CodeInstruction(OpCodes.Callvirt, typeof(IEnumerator).GetMethod(nameof(IEnumerator.MoveNext))),
-                new CodeInstruction(OpCodes.Brtrue_S, loopBodyLabel),
-                // Loop Head End
-                
-                // Dispose of IEnumerator
-                new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex),
-                new CodeInstruction(OpCodes.Callvirt, typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))),
-
-                // Call MetricsLogger.OnOxidePluginMetrics
-                new CodeInstruction(OpCodes.Ldsfld, hookFieldInfo),
-                new CodeInstruction(OpCodes.Ldloc, dictionaryLocal.LocalIndex),
-                new CodeInstruction(OpCodes.Call, hookMethodInfo)
-            });
-
-            return retList;
-        }
-    }
-}
+﻿// using HarmonyLib;
+// using System;
+// using System.Collections;
+// using System.Collections.Generic;
+// using System.Reflection;
+// using System.Reflection.Emit;
+//
+// namespace RustServerMetrics.HarmonyPatches
+// {
+//     [HarmonyPatch]
+//     public static class OxideMod_OnFrame_Patch
+//     {
+//         const string OxideCore_AssemblyName = "Oxide.Core";
+//
+//         const string OxidePluginType_FullName = "Oxide.Core.Plugins.Plugin";
+//         const string OxideInterfaceType_FullName = "Oxide.Core.Interface";
+//         const string OxideOxideModType_FullName = "Oxide.Core.OxideMod";
+//         const string OxidePluginManagerType_FullName = "Oxide.Core.Plugins.PluginManager";
+//
+//         static Assembly _oxideCoreAssembly = null;
+//         public static float nextTick = 0f;
+//
+//         [HarmonyTargetMethods]
+//         public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance)
+//         {
+//             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+//             for (int i = 0; i < assemblies.Length; i++)
+//             {
+//                 var assembly = assemblies[i];
+//                 if (!string.Equals(assembly.GetName().Name, OxideCore_AssemblyName, StringComparison.OrdinalIgnoreCase)) continue;
+//                 _oxideCoreAssembly = assembly;
+//                 break;
+//             }
+//
+//             if (_oxideCoreAssembly == null)
+//                 return Array.Empty<MethodBase>();
+//
+//             var oxideModType = _oxideCoreAssembly.GetType(OxideOxideModType_FullName, false);
+//
+//             if (oxideModType == null)
+//                 return Array.Empty<MethodBase>();
+//
+//             var targetMethod = oxideModType.GetMethod("OnFrame", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(float) }, null);
+//
+//             if (targetMethod == null)
+//                 return Array.Empty<MethodBase>();
+//
+//             return new MethodBase[] { targetMethod };
+//         }
+//
+//         [HarmonyTranspiler]
+//         public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> originalInstructions, ILGenerator ilGenerator)
+//         {
+//             var skipProcessingLabel = ilGenerator.DefineLabel();
+//             var loopHeadLabel = ilGenerator.DefineLabel();
+//             var loopBodyLabel = ilGenerator.DefineLabel();
+//
+//             var oxidePluginType = _oxideCoreAssembly.GetType(OxidePluginType_FullName, true);
+//             var enumerableType = typeof(IEnumerable<>);
+//             var oxidePluginEnumerableType = enumerableType.MakeGenericType(oxidePluginType);
+//             var enumeratorType = typeof(IEnumerator<>);
+//             var oxidePluginEnumeratorType = enumeratorType.MakeGenericType(oxidePluginType);
+//
+//             var enumeratorLocal = ilGenerator.DeclareLocal(oxidePluginEnumeratorType);
+//             var dictionaryLocal = ilGenerator.DeclareLocal(typeof(Dictionary<string, double>));
+//             var pluginLocal = ilGenerator.DeclareLocal(oxidePluginType);
+//             var currentTimeLocal = ilGenerator.DeclareLocal(typeof(float));
+//
+//             var nextTickFieldInfo = typeof(OxideMod_OnFrame_Patch).GetField(nameof(nextTick), BindingFlags.Public | BindingFlags.Static);
+//
+//             List<CodeInstruction> retList = new List<CodeInstruction>(originalInstructions);
+//
+//             retList[0].labels.Add(skipProcessingLabel);
+//
+//             var unityGetTimeMethodInfo = typeof(UnityEngine.Time).GetProperty(nameof(UnityEngine.Time.time)).GetGetMethod();
+//             var oxideGetterMethodInfo = _oxideCoreAssembly.GetType(OxideInterfaceType_FullName, true).GetProperty("Oxide").GetGetMethod();
+//             var rootPluginManagerGetterMethodInfo = _oxideCoreAssembly.GetType(OxideOxideModType_FullName, true).GetProperty("RootPluginManager").GetGetMethod();
+//             var getPluginsMethodInfo = _oxideCoreAssembly.GetType(OxidePluginManagerType_FullName, true).GetMethod("GetPlugins");
+//             var getPluginNameGetterMethodInfo = oxidePluginType.GetProperty("Name").GetGetMethod();
+//             var getPluginTotalHookTimeGetterMethodInfo = oxidePluginType.GetProperty("TotalHookTime").GetGetMethod();
+//             var getEnumeratorMethodInfo = oxidePluginEnumerableType.GetMethod("GetEnumerator");
+//
+//             var hookFieldInfo = typeof(SingletonComponent<MetricsLogger>)
+//                 .GetField(nameof(SingletonComponent<MetricsLogger>.Instance), BindingFlags.Static | BindingFlags.Public);
+//
+//             var hookMethodInfo = typeof(MetricsLogger)
+//                 .GetMethod(nameof(MetricsLogger.OnOxidePluginMetrics), BindingFlags.Instance | BindingFlags.NonPublic);
+//
+//             retList.InsertRange(0, new CodeInstruction[]
+//             {
+//                 new CodeInstruction(OpCodes.Ldsfld, hookFieldInfo),
+//                 new CodeInstruction(OpCodes.Brfalse_S, skipProcessingLabel),
+//
+//                 new CodeInstruction(OpCodes.Call, unityGetTimeMethodInfo),
+//                 new CodeInstruction(OpCodes.Stloc, currentTimeLocal.LocalIndex),
+//
+//                 new CodeInstruction(OpCodes.Ldsfld, nextTickFieldInfo),
+//                 new CodeInstruction(OpCodes.Ldloc, currentTimeLocal.LocalIndex),
+//                 new CodeInstruction(OpCodes.Bgt_S, skipProcessingLabel),
+//
+//                 new CodeInstruction(OpCodes.Ldloc, currentTimeLocal.LocalIndex),
+//                 new CodeInstruction(OpCodes.Ldc_R4, 1f),
+//                 new CodeInstruction(OpCodes.Add),
+//                 new CodeInstruction(OpCodes.Stsfld, nextTickFieldInfo),
+//
+//                 new CodeInstruction(OpCodes.Call, oxideGetterMethodInfo),
+//                 new CodeInstruction(OpCodes.Callvirt, rootPluginManagerGetterMethodInfo),
+//                 new CodeInstruction(OpCodes.Callvirt, getPluginsMethodInfo),
+//                 new CodeInstruction(OpCodes.Callvirt, getEnumeratorMethodInfo),
+//                 new CodeInstruction(OpCodes.Stloc, enumeratorLocal.LocalIndex),
+//
+//                 new CodeInstruction(OpCodes.Newobj, typeof(Dictionary<string, double>).GetConstructor(Type.EmptyTypes)),
+//                 new CodeInstruction(OpCodes.Stloc, dictionaryLocal.LocalIndex),
+//
+//                 // Jump to Loop Head
+//                 new CodeInstruction(OpCodes.Br_S, loopHeadLabel),
+//
+//                 // Loop Body Start
+//                 new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex) { labels = { loopBodyLabel } },
+//                 new CodeInstruction(OpCodes.Callvirt, oxidePluginEnumeratorType.GetProperty(nameof(IEnumerator.Current)).GetGetMethod()),
+//                 new CodeInstruction(OpCodes.Stloc, pluginLocal.LocalIndex),
+//                 new CodeInstruction(OpCodes.Ldloc, dictionaryLocal.LocalIndex),
+//                 new CodeInstruction(OpCodes.Ldloc, pluginLocal.LocalIndex),
+//                 new CodeInstruction(OpCodes.Callvirt, getPluginNameGetterMethodInfo),
+//                 new CodeInstruction(OpCodes.Ldloc, pluginLocal.LocalIndex),
+//                 new CodeInstruction(OpCodes.Callvirt, getPluginTotalHookTimeGetterMethodInfo),
+//                 new CodeInstruction(OpCodes.Callvirt, dictionaryLocal.LocalType.GetMethod("set_Item")),
+//                 // Loop Body End
+//
+//                 // Loop Head Start
+//                 new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex) { labels = { loopHeadLabel } },
+//                 new CodeInstruction(OpCodes.Callvirt, typeof(IEnumerator).GetMethod(nameof(IEnumerator.MoveNext))),
+//                 new CodeInstruction(OpCodes.Brtrue_S, loopBodyLabel),
+//                 // Loop Head End
+//                 
+//                 // Dispose of IEnumerator
+//                 new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex),
+//                 new CodeInstruction(OpCodes.Callvirt, typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))),
+//
+//                 // Call MetricsLogger.OnOxidePluginMetrics
+//                 new CodeInstruction(OpCodes.Ldsfld, hookFieldInfo),
+//                 new CodeInstruction(OpCodes.Ldloc, dictionaryLocal.LocalIndex),
+//                 new CodeInstruction(OpCodes.Call, hookMethodInfo)
+//             });
+//
+//             return retList;
+//         }
+//     }
+// }

--- a/src/RustServerMetrics/HarmonyPatches/OxideMod_OnFrame_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/OxideMod_OnFrame_Patch.cs
@@ -1,149 +1,173 @@
-﻿// using HarmonyLib;
-// using System;
-// using System.Collections;
-// using System.Collections.Generic;
-// using System.Reflection;
-// using System.Reflection.Emit;
-//
-// namespace RustServerMetrics.HarmonyPatches
-// {
-//     [HarmonyPatch]
-//     public static class OxideMod_OnFrame_Patch
-//     {
-//         const string OxideCore_AssemblyName = "Oxide.Core";
-//
-//         const string OxidePluginType_FullName = "Oxide.Core.Plugins.Plugin";
-//         const string OxideInterfaceType_FullName = "Oxide.Core.Interface";
-//         const string OxideOxideModType_FullName = "Oxide.Core.OxideMod";
-//         const string OxidePluginManagerType_FullName = "Oxide.Core.Plugins.PluginManager";
-//
-//         static Assembly _oxideCoreAssembly = null;
-//         public static float nextTick = 0f;
-//
-//         [HarmonyTargetMethods]
-//         public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance)
-//         {
-//             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-//             for (int i = 0; i < assemblies.Length; i++)
-//             {
-//                 var assembly = assemblies[i];
-//                 if (!string.Equals(assembly.GetName().Name, OxideCore_AssemblyName, StringComparison.OrdinalIgnoreCase)) continue;
-//                 _oxideCoreAssembly = assembly;
-//                 break;
-//             }
-//
-//             if (_oxideCoreAssembly == null)
-//                 return Array.Empty<MethodBase>();
-//
-//             var oxideModType = _oxideCoreAssembly.GetType(OxideOxideModType_FullName, false);
-//
-//             if (oxideModType == null)
-//                 return Array.Empty<MethodBase>();
-//
-//             var targetMethod = oxideModType.GetMethod("OnFrame", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(float) }, null);
-//
-//             if (targetMethod == null)
-//                 return Array.Empty<MethodBase>();
-//
-//             return new MethodBase[] { targetMethod };
-//         }
-//
-//         [HarmonyTranspiler]
-//         public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> originalInstructions, ILGenerator ilGenerator)
-//         {
-//             var skipProcessingLabel = ilGenerator.DefineLabel();
-//             var loopHeadLabel = ilGenerator.DefineLabel();
-//             var loopBodyLabel = ilGenerator.DefineLabel();
-//
-//             var oxidePluginType = _oxideCoreAssembly.GetType(OxidePluginType_FullName, true);
-//             var enumerableType = typeof(IEnumerable<>);
-//             var oxidePluginEnumerableType = enumerableType.MakeGenericType(oxidePluginType);
-//             var enumeratorType = typeof(IEnumerator<>);
-//             var oxidePluginEnumeratorType = enumeratorType.MakeGenericType(oxidePluginType);
-//
-//             var enumeratorLocal = ilGenerator.DeclareLocal(oxidePluginEnumeratorType);
-//             var dictionaryLocal = ilGenerator.DeclareLocal(typeof(Dictionary<string, double>));
-//             var pluginLocal = ilGenerator.DeclareLocal(oxidePluginType);
-//             var currentTimeLocal = ilGenerator.DeclareLocal(typeof(float));
-//
-//             var nextTickFieldInfo = typeof(OxideMod_OnFrame_Patch).GetField(nameof(nextTick), BindingFlags.Public | BindingFlags.Static);
-//
-//             List<CodeInstruction> retList = new List<CodeInstruction>(originalInstructions);
-//
-//             retList[0].labels.Add(skipProcessingLabel);
-//
-//             var unityGetTimeMethodInfo = typeof(UnityEngine.Time).GetProperty(nameof(UnityEngine.Time.time)).GetGetMethod();
-//             var oxideGetterMethodInfo = _oxideCoreAssembly.GetType(OxideInterfaceType_FullName, true).GetProperty("Oxide").GetGetMethod();
-//             var rootPluginManagerGetterMethodInfo = _oxideCoreAssembly.GetType(OxideOxideModType_FullName, true).GetProperty("RootPluginManager").GetGetMethod();
-//             var getPluginsMethodInfo = _oxideCoreAssembly.GetType(OxidePluginManagerType_FullName, true).GetMethod("GetPlugins");
-//             var getPluginNameGetterMethodInfo = oxidePluginType.GetProperty("Name").GetGetMethod();
-//             var getPluginTotalHookTimeGetterMethodInfo = oxidePluginType.GetProperty("TotalHookTime").GetGetMethod();
-//             var getEnumeratorMethodInfo = oxidePluginEnumerableType.GetMethod("GetEnumerator");
-//
-//             var hookFieldInfo = typeof(SingletonComponent<MetricsLogger>)
-//                 .GetField(nameof(SingletonComponent<MetricsLogger>.Instance), BindingFlags.Static | BindingFlags.Public);
-//
-//             var hookMethodInfo = typeof(MetricsLogger)
-//                 .GetMethod(nameof(MetricsLogger.OnOxidePluginMetrics), BindingFlags.Instance | BindingFlags.NonPublic);
-//
-//             retList.InsertRange(0, new CodeInstruction[]
-//             {
-//                 new CodeInstruction(OpCodes.Ldsfld, hookFieldInfo),
-//                 new CodeInstruction(OpCodes.Brfalse_S, skipProcessingLabel),
-//
-//                 new CodeInstruction(OpCodes.Call, unityGetTimeMethodInfo),
-//                 new CodeInstruction(OpCodes.Stloc, currentTimeLocal.LocalIndex),
-//
-//                 new CodeInstruction(OpCodes.Ldsfld, nextTickFieldInfo),
-//                 new CodeInstruction(OpCodes.Ldloc, currentTimeLocal.LocalIndex),
-//                 new CodeInstruction(OpCodes.Bgt_S, skipProcessingLabel),
-//
-//                 new CodeInstruction(OpCodes.Ldloc, currentTimeLocal.LocalIndex),
-//                 new CodeInstruction(OpCodes.Ldc_R4, 1f),
-//                 new CodeInstruction(OpCodes.Add),
-//                 new CodeInstruction(OpCodes.Stsfld, nextTickFieldInfo),
-//
-//                 new CodeInstruction(OpCodes.Call, oxideGetterMethodInfo),
-//                 new CodeInstruction(OpCodes.Callvirt, rootPluginManagerGetterMethodInfo),
-//                 new CodeInstruction(OpCodes.Callvirt, getPluginsMethodInfo),
-//                 new CodeInstruction(OpCodes.Callvirt, getEnumeratorMethodInfo),
-//                 new CodeInstruction(OpCodes.Stloc, enumeratorLocal.LocalIndex),
-//
-//                 new CodeInstruction(OpCodes.Newobj, typeof(Dictionary<string, double>).GetConstructor(Type.EmptyTypes)),
-//                 new CodeInstruction(OpCodes.Stloc, dictionaryLocal.LocalIndex),
-//
-//                 // Jump to Loop Head
-//                 new CodeInstruction(OpCodes.Br_S, loopHeadLabel),
-//
-//                 // Loop Body Start
-//                 new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex) { labels = { loopBodyLabel } },
-//                 new CodeInstruction(OpCodes.Callvirt, oxidePluginEnumeratorType.GetProperty(nameof(IEnumerator.Current)).GetGetMethod()),
-//                 new CodeInstruction(OpCodes.Stloc, pluginLocal.LocalIndex),
-//                 new CodeInstruction(OpCodes.Ldloc, dictionaryLocal.LocalIndex),
-//                 new CodeInstruction(OpCodes.Ldloc, pluginLocal.LocalIndex),
-//                 new CodeInstruction(OpCodes.Callvirt, getPluginNameGetterMethodInfo),
-//                 new CodeInstruction(OpCodes.Ldloc, pluginLocal.LocalIndex),
-//                 new CodeInstruction(OpCodes.Callvirt, getPluginTotalHookTimeGetterMethodInfo),
-//                 new CodeInstruction(OpCodes.Callvirt, dictionaryLocal.LocalType.GetMethod("set_Item")),
-//                 // Loop Body End
-//
-//                 // Loop Head Start
-//                 new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex) { labels = { loopHeadLabel } },
-//                 new CodeInstruction(OpCodes.Callvirt, typeof(IEnumerator).GetMethod(nameof(IEnumerator.MoveNext))),
-//                 new CodeInstruction(OpCodes.Brtrue_S, loopBodyLabel),
-//                 // Loop Head End
-//                 
-//                 // Dispose of IEnumerator
-//                 new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex),
-//                 new CodeInstruction(OpCodes.Callvirt, typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))),
-//
-//                 // Call MetricsLogger.OnOxidePluginMetrics
-//                 new CodeInstruction(OpCodes.Ldsfld, hookFieldInfo),
-//                 new CodeInstruction(OpCodes.Ldloc, dictionaryLocal.LocalIndex),
-//                 new CodeInstruction(OpCodes.Call, hookMethodInfo)
-//             });
-//
-//             return retList;
-//         }
-//     }
-// }
+﻿using HarmonyLib;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace RustServerMetrics.HarmonyPatches
+{
+    [HarmonyPatch]
+    public static class OxideMod_OnFrame_Patch
+    {
+        const string OxideCore_AssemblyName = "Oxide.Core";
+
+        const string OxidePluginType_FullName = "Oxide.Core.Plugins.Plugin";
+        const string OxideInterfaceType_FullName = "Oxide.Core.Interface";
+        const string OxideOxideModType_FullName = "Oxide.Core.OxideMod";
+        const string OxidePluginManagerType_FullName = "Oxide.Core.Plugins.PluginManager";
+
+        static Assembly _oxideCoreAssembly = null;
+        public static float nextTick = 0f;
+
+        [HarmonyPrepare]
+        public static bool Prepare()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            foreach (var assembly in assemblies)
+            {
+                if (!string.Equals(assembly.GetName().Name, OxideCore_AssemblyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                
+                _oxideCoreAssembly = assembly;
+                
+                break;
+            }
+
+            if (_oxideCoreAssembly == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+        
+        [HarmonyTargetMethods]
+        public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance)
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                var assembly = assemblies[i];
+                if (!string.Equals(assembly.GetName().Name, OxideCore_AssemblyName, StringComparison.OrdinalIgnoreCase)) continue;
+                _oxideCoreAssembly = assembly;
+                break;
+            }
+
+            if (_oxideCoreAssembly == null)
+                return Array.Empty<MethodBase>();
+
+            var oxideModType = _oxideCoreAssembly.GetType(OxideOxideModType_FullName, false);
+
+            if (oxideModType == null)
+                return Array.Empty<MethodBase>();
+
+            var targetMethod = oxideModType.GetMethod("OnFrame", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(float) }, null);
+
+            if (targetMethod == null)
+                return Array.Empty<MethodBase>();
+
+            return new MethodBase[] { targetMethod };
+        }
+
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> originalInstructions, ILGenerator ilGenerator)
+        {
+            var skipProcessingLabel = ilGenerator.DefineLabel();
+            var loopHeadLabel = ilGenerator.DefineLabel();
+            var loopBodyLabel = ilGenerator.DefineLabel();
+
+            var oxidePluginType = _oxideCoreAssembly.GetType(OxidePluginType_FullName, true);
+            var enumerableType = typeof(IEnumerable<>);
+            var oxidePluginEnumerableType = enumerableType.MakeGenericType(oxidePluginType);
+            var enumeratorType = typeof(IEnumerator<>);
+            var oxidePluginEnumeratorType = enumeratorType.MakeGenericType(oxidePluginType);
+
+            var enumeratorLocal = ilGenerator.DeclareLocal(oxidePluginEnumeratorType);
+            var dictionaryLocal = ilGenerator.DeclareLocal(typeof(Dictionary<string, double>));
+            var pluginLocal = ilGenerator.DeclareLocal(oxidePluginType);
+            var currentTimeLocal = ilGenerator.DeclareLocal(typeof(float));
+
+            var nextTickFieldInfo = typeof(OxideMod_OnFrame_Patch).GetField(nameof(nextTick), BindingFlags.Public | BindingFlags.Static);
+
+            List<CodeInstruction> retList = new List<CodeInstruction>(originalInstructions);
+
+            retList[0].labels.Add(skipProcessingLabel);
+
+            var unityGetTimeMethodInfo = typeof(UnityEngine.Time).GetProperty(nameof(UnityEngine.Time.time)).GetGetMethod();
+            var oxideGetterMethodInfo = _oxideCoreAssembly.GetType(OxideInterfaceType_FullName, true).GetProperty("Oxide").GetGetMethod();
+            var rootPluginManagerGetterMethodInfo = _oxideCoreAssembly.GetType(OxideOxideModType_FullName, true).GetProperty("RootPluginManager").GetGetMethod();
+            var getPluginsMethodInfo = _oxideCoreAssembly.GetType(OxidePluginManagerType_FullName, true).GetMethod("GetPlugins");
+            var getPluginNameGetterMethodInfo = oxidePluginType.GetProperty("Name").GetGetMethod();
+            var getPluginTotalHookTimeGetterMethodInfo = oxidePluginType.GetProperty("TotalHookTime").GetGetMethod();
+            var getEnumeratorMethodInfo = oxidePluginEnumerableType.GetMethod("GetEnumerator");
+
+            var hookFieldInfo = typeof(SingletonComponent<MetricsLogger>)
+                .GetField(nameof(SingletonComponent<MetricsLogger>.Instance), BindingFlags.Static | BindingFlags.Public);
+
+            var hookMethodInfo = typeof(MetricsLogger)
+                .GetMethod(nameof(MetricsLogger.OnOxidePluginMetrics), BindingFlags.Instance | BindingFlags.NonPublic);
+
+            retList.InsertRange(0, new CodeInstruction[]
+            {
+                new CodeInstruction(OpCodes.Ldsfld, hookFieldInfo),
+                new CodeInstruction(OpCodes.Brfalse_S, skipProcessingLabel),
+
+                new CodeInstruction(OpCodes.Call, unityGetTimeMethodInfo),
+                new CodeInstruction(OpCodes.Stloc, currentTimeLocal.LocalIndex),
+
+                new CodeInstruction(OpCodes.Ldsfld, nextTickFieldInfo),
+                new CodeInstruction(OpCodes.Ldloc, currentTimeLocal.LocalIndex),
+                new CodeInstruction(OpCodes.Bgt_S, skipProcessingLabel),
+
+                new CodeInstruction(OpCodes.Ldloc, currentTimeLocal.LocalIndex),
+                new CodeInstruction(OpCodes.Ldc_R4, 1f),
+                new CodeInstruction(OpCodes.Add),
+                new CodeInstruction(OpCodes.Stsfld, nextTickFieldInfo),
+
+                new CodeInstruction(OpCodes.Call, oxideGetterMethodInfo),
+                new CodeInstruction(OpCodes.Callvirt, rootPluginManagerGetterMethodInfo),
+                new CodeInstruction(OpCodes.Callvirt, getPluginsMethodInfo),
+                new CodeInstruction(OpCodes.Callvirt, getEnumeratorMethodInfo),
+                new CodeInstruction(OpCodes.Stloc, enumeratorLocal.LocalIndex),
+
+                new CodeInstruction(OpCodes.Newobj, typeof(Dictionary<string, double>).GetConstructor(Type.EmptyTypes)),
+                new CodeInstruction(OpCodes.Stloc, dictionaryLocal.LocalIndex),
+
+                // Jump to Loop Head
+                new CodeInstruction(OpCodes.Br_S, loopHeadLabel),
+
+                // Loop Body Start
+                new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex) { labels = { loopBodyLabel } },
+                new CodeInstruction(OpCodes.Callvirt, oxidePluginEnumeratorType.GetProperty(nameof(IEnumerator.Current)).GetGetMethod()),
+                new CodeInstruction(OpCodes.Stloc, pluginLocal.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc, dictionaryLocal.LocalIndex),
+                new CodeInstruction(OpCodes.Ldloc, pluginLocal.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, getPluginNameGetterMethodInfo),
+                new CodeInstruction(OpCodes.Ldloc, pluginLocal.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, getPluginTotalHookTimeGetterMethodInfo),
+                new CodeInstruction(OpCodes.Callvirt, dictionaryLocal.LocalType.GetMethod("set_Item")),
+                // Loop Body End
+
+                // Loop Head Start
+                new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex) { labels = { loopHeadLabel } },
+                new CodeInstruction(OpCodes.Callvirt, typeof(IEnumerator).GetMethod(nameof(IEnumerator.MoveNext))),
+                new CodeInstruction(OpCodes.Brtrue_S, loopBodyLabel),
+                // Loop Head End
+                
+                // Dispose of IEnumerator
+                new CodeInstruction(OpCodes.Ldloc, enumeratorLocal.LocalIndex),
+                new CodeInstruction(OpCodes.Callvirt, typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))),
+
+                // Call MetricsLogger.OnOxidePluginMetrics
+                new CodeInstruction(OpCodes.Ldsfld, hookFieldInfo),
+                new CodeInstruction(OpCodes.Ldloc, dictionaryLocal.LocalIndex),
+                new CodeInstruction(OpCodes.Call, hookMethodInfo)
+            });
+
+            return retList;
+        }
+    }
+}

--- a/src/RustServerMetrics/HarmonyPatches/Performance_FPSTimer_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Performance_FPSTimer_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 
 namespace RustServerMetrics.HarmonyPatches
 {

--- a/src/RustServerMetrics/HarmonyPatches/ServerMgr_OpenConnection_Patch.cs
+++ b/src/RustServerMetrics/HarmonyPatches/ServerMgr_OpenConnection_Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 
 namespace RustServerMetrics.HarmonyPatches
 {

--- a/src/RustServerMetrics/HarmonyPatches/Utility/Helpers.cs
+++ b/src/RustServerMetrics/HarmonyPatches/Utility/Helpers.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
-using Harmony;
+using HarmonyLib;
 using UnityEngine;
 
 namespace RustServerMetrics.HarmonyPatches.Utility;

--- a/src/RustServerMetrics/ModTimeWarnings.cs
+++ b/src/RustServerMetrics/ModTimeWarnings.cs
@@ -3,17 +3,31 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using Harmony;
+using HarmonyLib;
 using RustServerMetrics.HarmonyPatches.Utility;
+using UnityEngine;
 
 namespace RustServerMetrics;
 
+[HarmonyPatch]
 public static class ModTimeWarnings
 {
     public static List<MethodInfo> Methods = new ();
 
+    [HarmonyPrepare]
+    public static bool Prepare()
+    {
+        if (!RustServerMetricsLoader.__serverStarted)
+        {
+            Debug.Log("Cannot patch any time warnings yet. We will patch it upon server start.");
+            return false;
+        }
+
+        return true;
+    }
+    
     [HarmonyTargetMethods]
-    public static IEnumerable<MethodBase> TargetMethods(HarmonyInstance harmonyInstance) => Methods;
+    public static IEnumerable<MethodBase> TargetMethods(Harmony harmonyInstance) => Methods;
     
     [HarmonyTranspiler]
     public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> originalInstructions, MethodBase methodBase, ILGenerator ilGenerator)

--- a/src/RustServerMetrics/ModTimeWarnings.cs
+++ b/src/RustServerMetrics/ModTimeWarnings.cs
@@ -19,7 +19,7 @@ public static class ModTimeWarnings
     {
         if (!RustServerMetricsLoader.__serverStarted)
         {
-            Debug.Log("Cannot patch any time warnings yet. We will patch it upon server start.");
+            Debug.Log("Note: Cannot patch any time warnings yet. We will patch it upon server start.");
             return false;
         }
 

--- a/src/RustServerMetrics/RustServerMetricsLoader.cs
+++ b/src/RustServerMetrics/RustServerMetricsLoader.cs
@@ -1,15 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
-using Harmony;
-using RustServerMetrics.HarmonyPatches.Utility;
+using HarmonyLib;
 using UnityEngine;
 
 namespace RustServerMetrics;
 
 public class RustServerMetricsLoader : IHarmonyModHooks
 {
-    public static HarmonyInstance __harmonyInstance;
-    public static List<HarmonyInstance> __modTimeWarningsHarmonyInstances = new ();
+    public static bool __serverStarted = false;
+    
+    public static Harmony __harmonyInstance;
+    public static List<Harmony> __modTimeWarningsHarmonyInstances = new ();
     
     public void OnLoaded(OnHarmonyModLoadedArgs args)
     {
@@ -36,14 +37,13 @@ public class RustServerMetricsLoader : IHarmonyModHooks
 
     public void AddModTimeWarnings(List<MethodInfo> methods)
     { 
-        var instance = HarmonyInstance.Create($"RustServerMetrics.ModTimeWarnings.{__modTimeWarningsHarmonyInstances.Count}");
+        var instance = new Harmony($"RustServerMetrics.ModTimeWarnings.{__modTimeWarningsHarmonyInstances.Count}");
         __modTimeWarningsHarmonyInstances.Add(instance);
          
         ModTimeWarnings.Methods.Clear();
         ModTimeWarnings.Methods.AddRange(methods);
         
-        var attributes = HarmonyMethod.Merge(new List<HarmonyMethod> { new() });
-        var patchProcessor = new PatchProcessor(instance, typeof(ModTimeWarnings), attributes);
+        var patchProcessor = new PatchClassProcessor(instance, typeof(ModTimeWarnings));
         patchProcessor.Patch();
         
         foreach (var method in methods)


### PR DESCRIPTION
Due to Facepunch updating Harmony to 2.x with the May update, this PR contains the code changes necessary to continue running metrics after the update.

Due to changes in the Harmony library, there were some changes to how delayed patches are handled. It may be slightly messy but is fully functional which is my goal for the May update.

Fixes #18.